### PR TITLE
Ensure 'found_posts' is correct when no limit queries are in use

### DIFF
--- a/advanced-post-cache.php
+++ b/advanced-post-cache.php
@@ -227,8 +227,15 @@ class Advanced_Post_Cache {
 			return $found_posts;
 		}
 
-		if ( $this->found_posts && is_array( $this->all_post_ids ) ) // is cached
+		// Is cached
+		if ( $this->found_posts && is_array( $this->all_post_ids ) ) {
+			// Ensure no limit queries counts the post IDs array.
+			if ( 'NA' === $this->found_posts ) {
+				return count( $this->all_post_ids );
+			}
+
 			return (int) $this->found_posts;
+		}
 
 		call_user_func( $this->cache_func, "{$this->cache_key}_found", (int) $found_posts, $this->cache_group );
 		$this->need_to_flush_cache = true;


### PR DESCRIPTION
Currently, if `'no_found_rows'` is set to false for WP_Query, the returned `'found_rows'` property is zero instead of the number of posts.

`'found_posts'` is set to 'NA' here:
https://github.com/Automattic/advanced-post-cache/blob/c46b2d95773689938ef1e89a3dfcb9cbd94022b8/advanced-post-cache.php#L200-L201

And never redeclared.

So when `advanced-post-cache` gets to returning the found posts count:

https://github.com/Automattic/advanced-post-cache/blob/c46b2d95773689938ef1e89a3dfcb9cbd94022b8/advanced-post-cache.php#L230-L231

It returns 0 because of `(int) 'NA'`.

This PR fixes this by returning the count of the cached post IDs if `'found_posts'` is a no limit query (`'NA'`). This is important for plugins doing checks against `'found_posts'` and are anticipating a non-zero count. For example, bbPress does such a check here: https://github.com/bbpress/bbPress/blob/b772b4503991e3d55a34a4683a1f84e60decbce1/src/includes/replies/template.php#L212-L213

This addresses #4.