### PR TITLE
Flush cache on post meta changes

### DIFF
--- a/advanced-post-cache.php
+++ b/advanced-post-cache.php
@@ -255,6 +255,9 @@ function dont_clear_advanced_post_cache() {
 
 add_action( 'clean_term_cache', 'clear_advanced_post_cache' );
 add_action( 'clean_post_cache', 'clear_advanced_post_cache' );
+add_action( 'added_post_meta', 'clear_advanced_post_cache' );
+add_action( 'updated_post_meta', 'clear_advanced_post_cache' );
+add_action( 'deleted_post_meta', 'clear_advanced_post_cache' );
 
 // Don't clear Advanced Post Cache for a new comment - temp core hack
 // http://core.trac.wordpress.org/ticket/15565


### PR DESCRIPTION
https://github.com/Automattic/advanced-post-cache/pull/15 was using filters as actions, but they weren't returning anything, causing tests to fail. I've reverted it, but let's use the actual actions this time.