### PR TITLE
Restore cache increment if it was deleted elsewhere

### DIFF
--- a/advanced-post-cache.php
+++ b/advanced-post-cache.php
@@ -90,6 +90,10 @@ class Advanced_Post_Cache {
 //			return;
 
 		$this->cache_incr = wp_cache_incr( 'advanced_post_cache', 1, 'cache_incrementors' );
+		// We lost the increment along the way so recreate it.
+		if ( false === $this->cache_incr ) {
+			$this->setup_for_blog();
+		}
 		if ( 10 < strlen( $this->cache_incr ) ) {
 			wp_cache_set( 'advanced_post_cache', 0, 'cache_incrementors' );
 			$this->cache_incr = 0;


### PR DESCRIPTION
In order for `wp_cache_incr` to function there must be an existing number value in the cache. If the value does not exist, we must reset it to a number.

Use the existing `setup_for_blog` method to preserve original logic that runs when the class loads.

Situations where the cache value is lost:
1. Integration tests which flush the cache between tests.
2. The 'cache_incrementors' group is deleted by another plugin or theme.
3. The 'advanced_post_cache' key is deleted by another plugin or theme. 



