### PR TITLE
Add better readme and be explicit in plugin header and composer.json to indicate the plugin is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 advanced-post-cache
 =================
 
+🛑 DEPRECATION NOTICE
+--------
+
+Since WordPress 6.1 Core has now built-in WP_Query caching this plugin is now deprecated. If you're running 6.1+ we suggest removing all integrations dependent on it and disabling the plugin.
+
+Version 0.3.0 simply no-ops the functionality while preserving the API (to avoid potential fatals).
+
+If you're running an older version of WordPress we've prepared the [v0.2.0](https://github.com/Automattic/advanced-post-cache/releases/tag/v0.2.0) release.
+
+If you're installing this plugin via Composer please pin to the above tag.
+
+This repository will be archived soon.
+
 Overview
 --------
 

--- a/advanced-post-cache.php
+++ b/advanced-post-cache.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
-Plugin Name: Advanced Post Caching
-Description: Cache post queries. [DISABLED - functionality moved to WordPress core]
+Plugin Name: [DEPRECATED] Advanced Post Caching
+Description: [DEPRECATED] This plugin used to cache post queries, since WordPress 6.1 caching is built-in and this plugin is no longer needed.
 Version: 0.3.0
 Requires at least: 6.1
 Author: Automattic

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name"       : "automattic/advanced-post-cache",
-	"description": "Cache post queries for WordPress",
+	"description": "[DEPRECATED] Cache post queries for WordPress",
 	"homepage"   : "http://wordpress.org/plugins/advanced-caching/",
 	"type"       : "wordpress-plugin",
 	"license"    : "GPL-2.0+",


### PR DESCRIPTION
This pull request marks the deprecation of the `advanced-post-cache` plugin due to the introduction of built-in WP_Query caching in WordPress 6.1. The plugin's functionality has been disabled, and its repository is set to be archived. The changes ensure users are informed about its deprecation and guide them on transitioning away from the plugin.

### Deprecation Notice Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R4-R16): Added a deprecation notice explaining the plugin's status, suggesting removal for WordPress 6.1+ users, and providing guidance for older versions.

### Metadata Adjustments:
* [`advanced-post-cache.php`](diffhunk://#diff-2a2051b064c5ad72d059468ac8763d5d881ab1b980c27ab5c1eb9eb1128b82fbL4-R5): Updated the plugin name and description to include `[DEPRECATED]` and clarified the reason for deprecation.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L3-R3): Modified the package description to reflect the deprecation status.